### PR TITLE
Introducing aggregatable metrics as per issue 868

### DIFF
--- a/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
@@ -121,7 +121,7 @@ import io.grpc.protobuf.StatusProto;
 import io.grpc.stub.ServerCallStreamObserver;
 import io.prometheus.client.Counter;
 import io.prometheus.client.Gauge;
-import io.prometheus.client.Summary;
+import io.prometheus.client.Histogram;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -182,8 +182,8 @@ public class ShardInstance extends AbstractServerInstance {
   private static final Gauge queueSize =
       Gauge.build().name("queue_size").labelNames("queue_name").help("Queue size.").register();
 
-  private static final Summary ioMetric =
-      Summary.build().name("io_bytes_read").help("I/O (bytes)").register();
+  private static final Histogram ioMetric =
+      Histogram.build().name("io_bytes_read").help("I/O (bytes)").register();
 
   private final Runnable onStop;
   private final long maxBlobSize;

--- a/src/main/java/build/buildfarm/server/ContentAddressableStorageService.java
+++ b/src/main/java/build/buildfarm/server/ContentAddressableStorageService.java
@@ -47,7 +47,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import io.grpc.Status;
 import io.grpc.Status.Code;
 import io.grpc.stub.StreamObserver;
-import io.prometheus.client.Summary;
+import io.prometheus.client.Histogram;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -56,8 +56,8 @@ public class ContentAddressableStorageService
     extends ContentAddressableStorageGrpc.ContentAddressableStorageImplBase {
   private static final Logger logger =
       Logger.getLogger(ContentAddressableStorageService.class.getName());
-  private static final Summary missingBlobs =
-      Summary.build().name("missing_blobs").help("Find missing blobs.").register();
+  private static final Histogram missingBlobs =
+      Histogram.build().name("missing_blobs").help("Find missing blobs.").register();
 
   private final Instances instances;
   private final long writeDeadlineAfter;

--- a/src/main/java/build/buildfarm/server/WriteStreamObserver.java
+++ b/src/main/java/build/buildfarm/server/WriteStreamObserver.java
@@ -40,7 +40,7 @@ import io.grpc.Context;
 import io.grpc.Context.CancellableContext;
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
-import io.prometheus.client.Summary;
+import io.prometheus.client.Histogram;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -51,8 +51,8 @@ import javax.annotation.concurrent.GuardedBy;
 
 class WriteStreamObserver implements StreamObserver<WriteRequest> {
   private static final Logger logger = Logger.getLogger(WriteStreamObserver.class.getName());
-  private static final Summary ioMetric =
-      Summary.build().name("io_bytes_write").help("I/O (bytes)").register();
+  private static final Histogram ioMetric =
+      Histogram.build().name("io_bytes_write").help("I/O (bytes)").register();
 
   private final Instances instances;
   private final long deadlineAfter;

--- a/src/main/java/build/buildfarm/worker/ExecuteActionStage.java
+++ b/src/main/java/build/buildfarm/worker/ExecuteActionStage.java
@@ -17,7 +17,7 @@ package build.buildfarm.worker;
 import build.buildfarm.worker.resources.ResourceLimits;
 import com.google.common.collect.Sets;
 import io.prometheus.client.Gauge;
-import io.prometheus.client.Summary;
+import io.prometheus.client.Histogram;
 import java.io.IOException;
 import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
@@ -31,10 +31,10 @@ public class ExecuteActionStage extends SuperscalarPipelineStage {
   private static final Logger logger = Logger.getLogger(ExecuteActionStage.class.getName());
   private static final Gauge executionSlotUsage =
       Gauge.build().name("execution_slot_usage").help("Execution slot Usage.").register();
-  private static final Summary executionTime =
-      Summary.build().name("execution_time_ms").help("Execution time in ms.").register();
-  private static final Summary executionStallTime =
-      Summary.build()
+  private static final Histogram executionTime =
+      Histogram.build().name("execution_time_ms").help("Execution time in ms.").register();
+  private static final Histogram executionStallTime =
+      Histogram.build()
           .name("execution_stall_time_ms")
           .help("Execution stall time in ms.")
           .register();

--- a/src/main/java/build/buildfarm/worker/InputFetchStage.java
+++ b/src/main/java/build/buildfarm/worker/InputFetchStage.java
@@ -16,7 +16,7 @@ package build.buildfarm.worker;
 
 import com.google.common.collect.Sets;
 import io.prometheus.client.Gauge;
-import io.prometheus.client.Summary;
+import io.prometheus.client.Histogram;
 import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
@@ -26,10 +26,10 @@ public class InputFetchStage extends SuperscalarPipelineStage {
   private static final Logger logger = Logger.getLogger(InputFetchStage.class.getName());
   private static final Gauge inputFetchSlotUsage =
       Gauge.build().name("input_fetch_slot_usage").help("Input fetch slot Usage.").register();
-  private static final Summary inputFetchTime =
-      Summary.build().name("input_fetch_time_ms").help("Input fetch time in ms.").register();
-  private static final Summary inputFetchStallTime =
-      Summary.build()
+  private static final Histogram inputFetchTime =
+      Histogram.build().name("input_fetch_time_ms").help("Input fetch time in ms.").register();
+  private static final Histogram inputFetchStallTime =
+      Histogram.build()
           .name("input_fetch_stall_time_ms")
           .help("Input fetch stall time in ms.")
           .register();


### PR DESCRIPTION
This change updates the following summary metrics to instead report as histograms:

io_bytes_read
missing_blobs
io_bytes_write
execution_time_ms
execution_stall_time_ms
input_fetch_time_ms
input_fetch_stall_time_ms

This change will make these metrics aggregatable across servers and workers allowing easier tracking in dashboards and alerting mechanisms.